### PR TITLE
[mod] Replace 'ISP' by 'Internet Service Provider'

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
 
     <div class="slogan">
         <h2>Neutrinet</h2>
-        <h4>A Belgian associative network ISP, by its users for its users</h4>
+        <h4>A Belgian associative Internet Service Provider, by its users for its users</h4>
     </div>
 </section>
 <!-- /Section: intro -->


### PR DESCRIPTION
Many people do not know what 'ISP' stands for. This change replaces the acronym 'ISP' by the full name 'Internet Service Provider' on the front page so that every visitor landing on the page understands what Neutrinet is about.
