### PR TITLE
Fix past/next meeting mediawiki URLs

### DIFF
--- a/js/custom.js
+++ b/js/custom.js
@@ -9,7 +9,7 @@
     }
     var day = today.getDate();
     if (day < 10) {
-        var day = "0" + month;
+        var day = "0" + day;
     }
     var stupidlyUglyDateTimeFormatOfSemanticMerdiaWiki = year + "-2D" + month + "-2D" + day;
 


### PR DESCRIPTION
A typo in the 'day' var made the upcoming event from June 2nd appear in
the past events list (even though it's June 1st now)
